### PR TITLE
Fixing Content::Html on Ruby 1.9

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -266,7 +266,7 @@ module Atom # :nodoc:
         #
         begin
           node = XML::Node.new("#{namespace_map.prefix(Atom::NAMESPACE, name)}")
-          node << Iconv.iconv('utf-8', 'utf-8', self.to_s)
+          node << Iconv.iconv('utf-8', 'utf-8', self.to_s).first
           node['type'] = 'html'
           node['xml:lang'] = self.xml_lang if self.xml_lang
           node


### PR DESCRIPTION
Iconv returns an array, and because of changes to Array#to_s in Ruby 1.9
this results in outputting the string as an array: ["<p>Hello</p>"]

The solution is to simply use Array#first to pull the string out of the
array since there will only ever be one element in the array. This
should work for Ruby 1.8 and 1.9.
