### PR TITLE
include active_support/inflector explicitly

### DIFF
--- a/lib/atom/xml/parser.rb
+++ b/lib/atom/xml/parser.rb
@@ -27,6 +27,7 @@ unless String.instance_methods.include?(:demodulize)
     def demodulize
       self.sub(/.*::/, '')
     end
+  end
 end
 
 unless String.instance_methods.include?(:constantize)


### PR DESCRIPTION
A stab at fixing #5, which showed up for me on heroku, for whatever reason. Basically, the presence of `ActiveSupport` is not a strong enough signal to know for sure that `#singularize` and company are available (at least, for newish versions of activesupport). But if `ActiveSupport` _is_ available, it should be possible to require the inflector.

It should probably check the `ActiveSupport` version before doing that (since old versions won't have an `active_support/inflector`), but I'm not currently set up to test that, so I just wrapped it in a begin/rescue/end so that it at least can't do any real damage. If you want that fixed before you merge, I wouldn't blame you.

The other approach would be to simply check if `String.instance_methods.include?(:singularize)` and do all the work if it isn't, regardless of the availability of `ActiveSupport`.
