### PR TITLE
Make ratom compatible with ruby 1.8.7

### DIFF
--- a/lib/atom/xml/parser.rb
+++ b/lib/atom/xml/parser.rb
@@ -10,7 +10,7 @@ require 'time'
 RootCA = '/etc/ssl/certs'
 
 # Just a couple methods form transforming strings
-unless String.instance_methods.include?(:singularize)
+unless "".respond_to?(:singularize)
   class String # :nodoc:
     def singularize
       if self =~ /ies$/
@@ -22,7 +22,7 @@ unless String.instance_methods.include?(:singularize)
   end
 end
 
-unless String.instance_methods.include?(:demodulize)
+unless "".respond_to?(:demodulize)
   class String # :nodoc:
     def demodulize
       self.sub(/.*::/, '')
@@ -30,7 +30,7 @@ unless String.instance_methods.include?(:demodulize)
   end
 end
 
-unless String.instance_methods.include?(:constantize)
+unless "".respond_to?(:constantize)
   class String # :nodoc:   
     def constantize
       Object.module_eval("::#{self}", __FILE__, __LINE__)


### PR DESCRIPTION
instance_methods returns an array of strings in Ruby 1.8.x as opposed to symbols in 1.9.x.

This broke our rails app completely.

I've changed it to use instance_of? instead which should work in all versions of Ruby.
