### PR TITLE
Valid UTF-8 strings that contain non-ascii chars should be allowed in to_xml.

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -301,10 +301,11 @@ module Atom # :nodoc:
           end
 
         else
+          self_string = self.to_s
 
-          if self.to_s.force_encoding("UTF-8").ascii_only?
+          if self_string.dup.force_encoding("UTF-8").valid_encoding?
             node = XML::Node.new("#{namespace_map.prefix(Atom::NAMESPACE, name)}")
-            node << self.to_s
+            node << self_string
             node['type'] = 'html'
             node['xml:lang'] = self.xml_lang if self.xml_lang
             node

--- a/spec/atom_spec.rb
+++ b/spec/atom_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Copyright (c) 2008 The Kaphan Foundation
 #
 # For licensing information see LICENSE.
@@ -1231,8 +1232,18 @@ describe Atom do
           entry.title = "My entry"
           entry.id = "urn:entry:1"
           entry.content = Atom::Content::Html.new("this is not \227 utf8")
-        end.to_xml)  
-      }.should raise_error(Atom::SerializationError)      
+        end.to_xml)
+      }.should raise_error(Atom::SerializationError)
+    end
+
+    it "should not raise error when to_xml'ing utf8 but non-ascii content" do
+      xml = Atom::Entry.new do |entry|
+        entry.title = "My entry"
+        entry.id = "urn:entry:1"
+        entry.content = Atom::Content::Html.new("Žižek is utf8")
+      end.to_xml
+
+      xml.should match(/Žižek/)
     end
   end
   


### PR DESCRIPTION
I found a case where the ruby 1.9 UTF-8 check I added in 1d71227e95 was rejecting valid utf-8 strings :( I think this is more correct now.
