### PR TITLE
Atom schema testing

### DIFF
--- a/ratom.gemspec
+++ b/ratom.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.1.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
+      s.add_development_dependency(%q<nokogiri>, ["~> 1.5.6"])
     else
       s.add_dependency(%q<libxml-ruby>, ["~> 2.3.2"])
       s.add_dependency(%q<bundler>, ["~> 1.1.0"])

--- a/spec/atom_spec.rb
+++ b/spec/atom_spec.rb
@@ -889,6 +889,48 @@ describe Atom do
         end
       end
     end
+
+    describe 'atom.rng' do
+
+      before(:all) do
+        require 'nokogiri'
+        rng_schema = File.expand_path("conformance/atom.rng",
+                                      File.dirname(__FILE__))
+        @schema = Nokogiri::XML::RelaxNG(File.open(rng_schema))
+      end
+
+      def validate_against_atom_rng
+        @schema.validate(Nokogiri::XML(subject.to_xml)).should be == []
+      end
+
+      subject do
+        Atom::Feed.new do |feed|
+          # Order is important
+          feed.id = "http://example.test/feed"
+          feed.updated = DateTime.now
+          feed.title = 'Test Feed'
+          # Add entries
+          feed.entries << Atom::Entry.new do |entry|
+            entry.id = "http://example.test/entry/1"
+            entry.updated = feed.updated
+            entry.title = 'Test Entry'
+          end
+        end
+      end
+
+      it 'should validate against a feed without extensions' do
+        validate_against_atom_rng
+      end
+
+      it 'should validate against a feed with simple extensions' do
+        pending 'Does not conform yet - see seangeo/ratom#21'
+        # Mark feed as complete
+        subject['http://purl.org/syndication/history/1.0', 'complete'] << ''
+        validate_against_atom_rng
+      end
+
+    end
+
   end
   
   describe 'pagination' do

--- a/spec/conformance/atom.rng
+++ b/spec/conformance/atom.rng
@@ -1,0 +1,600 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  -*- rnc -*-
+  RELAX NG XML Syntax Grammar for the
+  Atom Format Specification Version 11
+
+  Converted from Relax NG Compact Syntax Grammar,
+  as seen in RFC 4287.
+-->
+<grammar ns="http://www.w3.org/1999/xhtml" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:s="http://www.ascc.net/xml/schematron" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <choice>
+      <ref name="atomFeed"/>
+      <ref name="atomEntry"/>
+    </choice>
+  </start>
+  <!-- Common attributes -->
+  <define name="atomCommonAttributes">
+    <optional>
+      <attribute name="xml:base">
+        <ref name="atomUri"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xml:lang">
+        <ref name="atomLanguageTag"/>
+      </attribute>
+    </optional>
+    <zeroOrMore>
+      <ref name="undefinedAttribute"/>
+    </zeroOrMore>
+  </define>
+  <!-- Text Constructs -->
+  <define name="atomPlainTextConstruct">
+    <ref name="atomCommonAttributes"/>
+    <optional>
+      <attribute name="type">
+        <choice>
+          <value>text</value>
+          <value>html</value>
+        </choice>
+      </attribute>
+    </optional>
+    <text/>
+  </define>
+  <define name="atomXHTMLTextConstruct">
+    <ref name="atomCommonAttributes"/>
+    <attribute name="type">
+      <value>xhtml</value>
+    </attribute>
+    <ref name="xhtmlDiv"/>
+  </define>
+  <define name="atomTextConstruct">
+    <choice>
+      <ref name="atomPlainTextConstruct"/>
+      <ref name="atomXHTMLTextConstruct"/>
+    </choice>
+  </define>
+  <!-- Person Construct -->
+  <define name="atomPersonConstruct">
+    <ref name="atomCommonAttributes"/>
+    <interleave>
+      <element name="atom:name">
+        <text/>
+      </element>
+      <optional>
+        <element name="atom:uri">
+          <ref name="atomUri"/>
+        </element>
+      </optional>
+      <optional>
+        <element name="atom:email">
+          <ref name="atomEmailAddress"/>
+        </element>
+      </optional>
+      <zeroOrMore>
+        <ref name="extensionElement"/>
+      </zeroOrMore>
+    </interleave>
+  </define>
+  <!-- Date Construct -->
+  <define name="atomDateConstruct">
+    <ref name="atomCommonAttributes"/>
+    <data type="dateTime"/>
+  </define>
+  <!-- atom:feed -->
+  <define name="atomFeed">
+    <element name="atom:feed">
+      <s:rule context="atom:feed">
+        <s:assert test="atom:author or not(atom:entry[not(atom:author)])">An atom:feed must have an atom:author unless all of its atom:entry children have an atom:author.</s:assert>
+      </s:rule>
+      <ref name="atomCommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="atomAuthor"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="atomCategory"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="atomContributor"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomGenerator"/>
+        </optional>
+        <optional>
+          <ref name="atomIcon"/>
+        </optional>
+        <ref name="atomId"/>
+        <zeroOrMore>
+          <ref name="atomLink"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomLogo"/>
+        </optional>
+        <optional>
+          <ref name="atomRights"/>
+        </optional>
+        <optional>
+          <ref name="atomSubtitle"/>
+        </optional>
+        <ref name="atomTitle"/>
+        <ref name="atomUpdated"/>
+        <zeroOrMore>
+          <ref name="extensionElement"/>
+        </zeroOrMore>
+      </interleave>
+      <zeroOrMore>
+        <ref name="atomEntry"/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- atom:entry -->
+  <define name="atomEntry">
+    <element name="atom:entry">
+      <s:rule context="atom:entry">
+        <s:assert test="atom:link[@rel='alternate'] or atom:link[not(@rel)] or atom:content">An atom:entry must have at least one atom:link element with a rel attribute of 'alternate' or an atom:content.</s:assert>
+      </s:rule>
+      <s:rule context="atom:entry">
+        <s:assert test="atom:author or ../atom:author or atom:source/atom:author">An atom:entry must have an atom:author if its feed does not.</s:assert>
+      </s:rule>
+      <ref name="atomCommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="atomAuthor"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="atomCategory"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomContent"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="atomContributor"/>
+        </zeroOrMore>
+        <ref name="atomId"/>
+        <zeroOrMore>
+          <ref name="atomLink"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomPublished"/>
+        </optional>
+        <optional>
+          <ref name="atomRights"/>
+        </optional>
+        <optional>
+          <ref name="atomSource"/>
+        </optional>
+        <optional>
+          <ref name="atomSummary"/>
+        </optional>
+        <ref name="atomTitle"/>
+        <ref name="atomUpdated"/>
+        <zeroOrMore>
+          <ref name="extensionElement"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <!-- atom:content -->
+  <define name="atomInlineTextContent">
+    <element name="atom:content">
+      <ref name="atomCommonAttributes"/>
+      <optional>
+        <attribute name="type">
+          <choice>
+            <value>text</value>
+            <value>html</value>
+          </choice>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <text/>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="atomInlineXHTMLContent">
+    <element name="atom:content">
+      <ref name="atomCommonAttributes"/>
+      <attribute name="type">
+        <value>xhtml</value>
+      </attribute>
+      <ref name="xhtmlDiv"/>
+    </element>
+  </define>
+  <define name="atomInlineOtherContent">
+    <element name="atom:content">
+      <ref name="atomCommonAttributes"/>
+      <optional>
+        <attribute name="type">
+          <ref name="atomMediaType"/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="atomOutOfLineContent">
+    <element name="atom:content">
+      <ref name="atomCommonAttributes"/>
+      <optional>
+        <attribute name="type">
+          <ref name="atomMediaType"/>
+        </attribute>
+      </optional>
+      <attribute name="src">
+        <ref name="atomUri"/>
+      </attribute>
+      <empty/>
+    </element>
+  </define>
+  <define name="atomContent">
+    <choice>
+      <ref name="atomInlineTextContent"/>
+      <ref name="atomInlineXHTMLContent"/>
+      <ref name="atomInlineOtherContent"/>
+      <ref name="atomOutOfLineContent"/>
+    </choice>
+  </define>
+  <!-- atom:author -->
+  <define name="atomAuthor">
+    <element name="atom:author">
+      <ref name="atomPersonConstruct"/>
+    </element>
+  </define>
+  <!-- atom:category -->
+  <define name="atomCategory">
+    <element name="atom:category">
+      <ref name="atomCommonAttributes"/>
+      <attribute name="term"/>
+      <optional>
+        <attribute name="scheme">
+          <ref name="atomUri"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="label"/>
+      </optional>
+      <ref name="undefinedContent"/>
+    </element>
+  </define>
+  <!-- atom:contributor -->
+  <define name="atomContributor">
+    <element name="atom:contributor">
+      <ref name="atomPersonConstruct"/>
+    </element>
+  </define>
+  <!-- atom:generator -->
+  <define name="atomGenerator">
+    <element name="atom:generator">
+      <ref name="atomCommonAttributes"/>
+      <optional>
+        <attribute name="uri">
+          <ref name="atomUri"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="version"/>
+      </optional>
+      <text/>
+    </element>
+  </define>
+  <!-- atom:icon -->
+  <define name="atomIcon">
+    <element name="atom:icon">
+      <ref name="atomCommonAttributes"/>
+      <ref name="atomUri"/>
+    </element>
+  </define>
+  <!-- atom:id -->
+  <define name="atomId">
+    <element name="atom:id">
+      <ref name="atomCommonAttributes"/>
+      <ref name="atomUri"/>
+    </element>
+  </define>
+  <!-- atom:logo -->
+  <define name="atomLogo">
+    <element name="atom:logo">
+      <ref name="atomCommonAttributes"/>
+      <ref name="atomUri"/>
+    </element>
+  </define>
+  <!-- atom:link -->
+  <define name="atomLink">
+    <element name="atom:link">
+      <ref name="atomCommonAttributes"/>
+      <attribute name="href">
+        <ref name="atomUri"/>
+      </attribute>
+      <optional>
+        <attribute name="rel">
+          <choice>
+            <ref name="atomNCName"/>
+            <ref name="atomUri"/>
+          </choice>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="type">
+          <ref name="atomMediaType"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="hreflang">
+          <ref name="atomLanguageTag"/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="title"/>
+      </optional>
+      <optional>
+        <attribute name="length"/>
+      </optional>
+      <ref name="undefinedContent"/>
+    </element>
+  </define>
+  <!-- atom:published -->
+  <define name="atomPublished">
+    <element name="atom:published">
+      <ref name="atomDateConstruct"/>
+    </element>
+  </define>
+  <!-- atom:rights -->
+  <define name="atomRights">
+    <element name="atom:rights">
+      <ref name="atomTextConstruct"/>
+    </element>
+  </define>
+  <!-- atom:source -->
+  <define name="atomSource">
+    <element name="atom:source">
+      <ref name="atomCommonAttributes"/>
+      <interleave>
+        <zeroOrMore>
+          <ref name="atomAuthor"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="atomCategory"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="atomContributor"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomGenerator"/>
+        </optional>
+        <optional>
+          <ref name="atomIcon"/>
+        </optional>
+        <optional>
+          <ref name="atomId"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="atomLink"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="atomLogo"/>
+        </optional>
+        <optional>
+          <ref name="atomRights"/>
+        </optional>
+        <optional>
+          <ref name="atomSubtitle"/>
+        </optional>
+        <optional>
+          <ref name="atomTitle"/>
+        </optional>
+        <optional>
+          <ref name="atomUpdated"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="extensionElement"/>
+        </zeroOrMore>
+      </interleave>
+    </element>
+  </define>
+  <!-- atom:subtitle -->
+  <define name="atomSubtitle">
+    <element name="atom:subtitle">
+      <ref name="atomTextConstruct"/>
+    </element>
+  </define>
+  <!-- atom:summary -->
+  <define name="atomSummary">
+    <element name="atom:summary">
+      <ref name="atomTextConstruct"/>
+    </element>
+  </define>
+  <!-- atom:title -->
+  <define name="atomTitle">
+    <element name="atom:title">
+      <ref name="atomTextConstruct"/>
+    </element>
+  </define>
+  <!-- atom:updated -->
+  <define name="atomUpdated">
+    <element name="atom:updated">
+      <ref name="atomDateConstruct"/>
+    </element>
+  </define>
+  <!-- Low-level simple types -->
+  <define name="atomNCName">
+    <data type="string">
+      <param name="minLength">1</param>
+      <param name="pattern">[^:]*</param>
+    </data>
+  </define>
+  <!-- Whatever a media type is, it contains at least one slash -->
+  <define name="atomMediaType">
+    <data type="string">
+      <param name="pattern">.+/.+</param>
+    </data>
+  </define>
+  <!-- As defined in RFC 3066 -->
+  <define name="atomLanguageTag">
+    <data type="string">
+      <param name="pattern">[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*</param>
+    </data>
+  </define>
+  <!--
+    Unconstrained; it's not entirely clear how IRI fit into
+    xsd:anyURI so let's not try to constrain it here
+  -->
+  <define name="atomUri">
+    <text/>
+  </define>
+  <!-- Whatever an email address is, it contains at least one @ -->
+  <define name="atomEmailAddress">
+    <data type="string">
+      <param name="pattern">.+@.+</param>
+    </data>
+  </define>
+  <!-- Simple Extension -->
+  <define name="simpleExtensionElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://www.w3.org/2005/Atom"/>
+        </except>
+      </anyName>
+      <text/>
+    </element>
+  </define>
+  <!-- Structured Extension -->
+  <define name="structuredExtensionElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://www.w3.org/2005/Atom"/>
+        </except>
+      </anyName>
+      <choice>
+        <group>
+          <oneOrMore>
+            <attribute>
+              <anyName/>
+            </attribute>
+          </oneOrMore>
+          <zeroOrMore>
+            <choice>
+              <text/>
+              <ref name="anyElement"/>
+            </choice>
+          </zeroOrMore>
+        </group>
+        <group>
+          <zeroOrMore>
+            <attribute>
+              <anyName/>
+            </attribute>
+          </zeroOrMore>
+          <group>
+            <optional>
+              <text/>
+            </optional>
+            <oneOrMore>
+              <ref name="anyElement"/>
+            </oneOrMore>
+            <zeroOrMore>
+              <choice>
+                <text/>
+                <ref name="anyElement"/>
+              </choice>
+            </zeroOrMore>
+          </group>
+        </group>
+      </choice>
+    </element>
+  </define>
+  <!-- Other Extensibility -->
+  <define name="extensionElement">
+    <choice>
+      <ref name="simpleExtensionElement"/>
+      <ref name="structuredExtensionElement"/>
+    </choice>
+  </define>
+  <define name="undefinedAttribute">
+    <attribute>
+      <anyName>
+        <except>
+          <name>xml:base</name>
+          <name>xml:lang</name>
+          <nsName ns=""/>
+        </except>
+      </anyName>
+    </attribute>
+  </define>
+  <define name="undefinedContent">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="anyForeignElement"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="anyElement">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="anyForeignElement">
+    <element>
+      <anyName>
+        <except>
+          <nsName ns="http://www.w3.org/2005/Atom"/>
+        </except>
+      </anyName>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <!-- XHTML -->
+  <define name="anyXHTML">
+    <element>
+      <nsName/>
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyXHTML"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="xhtmlDiv">
+    <element name="xhtml:div">
+      <zeroOrMore>
+        <choice>
+          <attribute>
+            <anyName/>
+          </attribute>
+          <text/>
+          <ref name="anyXHTML"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+</grammar>


### PR DESCRIPTION
As noted in #21, the schema for Atom is documented in RFC 4287 as RELAX NG (compact).

This request adds testing against the schema (converted to RELAX NG XML).

Simple extensions for feeds don't currently validate against the schema, so that test is listed as "pending".
