### PR TITLE
Allowing newer libxml-ruby to handle libxml >= 2.9

### DIFF
--- a/ratom.gemspec
+++ b/ratom.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.3.2"])
-      s.add_development_dependency(%q<bundler>, ["~> 1.1.0"])
+      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.3"])
+      s.add_development_dependency(%q<bundler>, ["~> 1.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
     else
-      s.add_dependency(%q<libxml-ruby>, ["~> 2.3.2"])
-      s.add_dependency(%q<bundler>, ["~> 1.1.0"])
+      s.add_dependency(%q<libxml-ruby>, ["~> 2.3"])
+      s.add_dependency(%q<bundler>, ["~> 1.1"])
       s.add_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_dependency(%q<rake>, ["~> 0.9.2"])
     end


### PR DESCRIPTION
`libxml >= 2.9.0` needs `libxml-ruby >= 2.4.0`. See xml4r/libxml-ruby#49 for details.

This fixes builds on Fedora 18, and any other distros that come out with an up-to-date version of libxml2.
