### PR TITLE
add support for custom content type parser

### DIFF
--- a/lib/atom.rb
+++ b/lib/atom.rb
@@ -173,14 +173,8 @@ module Atom # :nodoc:
       if xml['src'] && !xml['src'].empty?
         External.new(xml)
       else
-        case xml['type']
-        when "xhtml"
-          Xhtml.new(xml)
-        when "html"
-          Html.new(xml)
-        else
-          Text.new(xml)
-        end
+        parser = PARSERS[xml['type']] || Text
+        parser.new(xml)
       end
     end
   
@@ -364,6 +358,8 @@ module Atom # :nodoc:
         node
       end
     end
+
+    PARSERS = {'html' => Html, 'xhtml' => Xhtml}
   end
    
   # Represents a Source as defined by the Atom Syndication Format specification.

--- a/spec/atom_spec.rb
+++ b/spec/atom_spec.rb
@@ -1179,7 +1179,18 @@ describe Atom do
       @entry.ns_alias_property.map { |x| [x.name, x.value] }.should == [['foo', 'bar'], ['baz', 'bat']]
     end
   end
-  
+
+  describe 'custom content type extensions' do
+    before(:all) do
+      Atom::Content::PARSERS['custom-content-type/xml'] = Atom::Content::Xhtml
+      @entry = Atom::Entry.load_entry(File.open('spec/fixtures/entry_with_custom_content_type.atom'))
+    end
+
+    it "should parse content by specified content parser" do
+      @entry.content.should == '<changes xmlns="http://www.xxx.com/app"/>'
+    end
+  end
+
   describe 'single custom_extensions' do
      before(:all) do
        Atom::Entry.add_extension_namespace :custom, "http://single.custom.namespace"

--- a/spec/fixtures/entry_with_custom_content_type.atom
+++ b/spec/fixtures/entry_with_custom_content_type.atom
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<entry xmlns='http://www.w3.org/2005/Atom' xmlns:custom='http://custom.namespace'>
+  <title>Atom-Powered Robots Run Amok</title>
+  <link href="http://example.org/2003/12/13/atom03"/>
+  <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+  <content type="custom-content-type/xml">
+    <changes xmlns="http://www.xxx.com/app"/>
+  </content>
+  <updated>2003-12-13T18:30:02Z</updated>
+</entry>


### PR DESCRIPTION
The atom:content element can be an extension point for application to publish its own format data as content of the entry.

Add new Atom::Content parser by: Atom::Content::PARSERS['custom-type/xml'] = ParserClass

reference: http://www.ietf.org/rfc/rfc4287.txt 4.1.3.3.4
