### PR TITLE
Update libxml-ruby version

### DIFF
--- a/ratom.gemspec
+++ b/ratom.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.6.0"])
+      s.add_runtime_dependency(%q<libxml-ruby>, [">= 2.6.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_development_dependency(%q<rake>, ["~> 0.9.2"])


### PR DESCRIPTION
Installing was giving me compile errors with Ruby 2.2.0 and libxml-ruby 2.6.0 - allowing the gem to to use libxml-2.7.0 helped the `gem install ratom` succeed without error.