### PR TITLE
Use LibXML-ruby 2.8.0

### DIFF
--- a/ratom.gemspec
+++ b/ratom.gemspec
@@ -23,19 +23,19 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.6"])
+      s.add_runtime_dependency(%q<libxml-ruby>, ["~> 2.8"])
       s.add_development_dependency(%q<bundler>, ["~> 1.1"])
       s.add_development_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_development_dependency(%q<rake>, ["~> 0.9.2"])
       s.add_development_dependency(%q<nokogiri>, ["~> 1.5.6"])
     else
-      s.add_dependency(%q<libxml-ruby>, ["~> 2.6"])
+      s.add_dependency(%q<libxml-ruby>, ["~> 2.8"])
       s.add_dependency(%q<bundler>, ["~> 1.1"])
       s.add_dependency(%q<rspec>, ["~> 2.10.0"])
       s.add_dependency(%q<rake>, ["~> 0.9.2"])
     end
   else
-    s.add_dependency(%q<libxml-ruby>, ["~> 2.6"])
+    s.add_dependency(%q<libxml-ruby>, ["~> 2.8"])
     s.add_dependency(%q<bundler>, ["~> 1.1.0"])
     s.add_dependency(%q<rspec>, ["~> 2.10.0"])
     s.add_dependency(%q<rake>, ["~> 0.9.2"])


### PR DESCRIPTION
Hello,

For some reason I was having trouble installing v2.6.x of libxml-ruby, so I installed the latest version of the gem and I ran ratom's specs and they all pass.

Hope this helps.

Regards,
iain
